### PR TITLE
docs: integrate br, bv, and MCP Agent Mail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,21 +31,22 @@ When tackling any non-trivial task:
 
 ## Integrated Workflow
 
-- **[Beads](https://github.com/steveyegge/beads/)** (`bd`) — Single system of record for ALL work. Git-backed issue tracking in `.beads/`.
+- **[Beads](https://github.com/steveyegge/beads/)** (`br`) — Single system of record for ALL work. Git-backed issue tracking in `.beads/`.
+- **[Beads Viewer](https://github.com/Dicklesworthstone/beads_viewer)** (`bv`) — Graph-aware triage engine. Use `bv --robot-triage` for work prioritization and dependency analysis. **Never run bare `bv`** (launches interactive TUI).
 - **[OpenSpec](https://github.com/Fission-AI/OpenSpec)** — Planning scratchpad for structured thinking. Artifacts in `openspec/` are temporary.
 
 See `AGENTS.md` for the complete workflow, commit discipline, and session close protocol.
 
 ## Issue Tracking Rules
 
-### Every `bd create` MUST include `-d`
+### Every `br create` MUST include `-d`
 
 ```bash
 # FORBIDDEN — will be rejected
-bd create "Update file.ts" -t task
+br create "Update file.ts" -t task
 
 # REQUIRED — every issue needs full context
-bd create "Title" -t task -p 2 -d "## Requirements
+br create "Title" -t task -p 2 -d "## Requirements
 - What needs to be done
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary

- **Migrate bd → br (beads_rust)**: Replace all `bd` commands with `br` equivalents, update sync mechanics from `bd sync` (auto-commit) to `br sync --flush-only` (manual git steps), remove daemon section
- **Add Beads Viewer (bv)**: Full AI sidecar reference in AGENTS.md, triage-first workflow (`bv --robot-triage`), command reference tables in README
- **Add MCP Agent Mail**: Multi-agent coordination section in AGENTS.md, setup guide in README (MCP server config, `AGENT_NAME` env var, usage examples, Beads integration mapping)
- **Deduplicate AGENTS.md**: Consolidate repeated bv command listings, sync sequences, and wave commit rules into cross-references

## Files Changed

| File | Changes |
|------|---------|
| `AGENTS.md` | bd→br migration, bv sidecar section, Agent Mail section, Beads+Mail integration, deduplication |
| `CLAUDE.md` | bd→br migration, add bv reference, add AGENTS.md cross-reference |
| `README.md` | bd→br migration, add bv throughout, add Agent Mail setup section, triage-first workflow |

## Test plan

- [ ] Verify all `bd` references are replaced with `br` equivalents
- [ ] Verify `bv --robot-*` commands are documented consistently across AGENTS.md and README.md
- [ ] Verify MCP Agent Mail setup section includes server config, env setup, and usage examples
- [ ] Verify internal cross-references (markdown links) resolve correctly
- [ ] Verify no broken links to external repos (beads, beads_viewer, mcp_agent_mail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)