### PR TITLE
docs: mandate git worktrees for feature branch isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,19 @@ Check the work type against the Git Branch Strategy table in `AGENTS.md`:
 | Documentation update | NO — direct to `main` |
 | Config change | NO — direct to `main` |
 
-**If YES:** Create the feature branch before any edits. See `AGENTS.md` "Complete Feature Branch Workflow" for the full sequence.
+**If YES:** Create a **git worktree** for the feature branch — never use `git checkout` in the shared repo. See `AGENTS.md` "Branch Isolation with Git Worktrees" and "Complete Feature Branch Workflow" for the full sequence.
+
+```bash
+git branch feature/<name>                                              # Create branch
+git worktree add /tmp/<project>-<name> feature/<name>                  # Create worktree
+cd /tmp/<project>-<name> && npm install                                # Enter + install deps
+```
 
 ### Pre-Edit Verification
 
 Before the first file edit, confirm:
 
-1. [ ] **Correct branch** — Am I on the right branch for this work type?
+1. [ ] **Correct branch/worktree** — Am I on the right branch? If feature work, am I in the worktree (`/tmp/<project>-<name>`), NOT the main repo?
 2. [ ] **Bead exists** — Is there a bead for this work? (`br show <id>`)
 3. [ ] **Bead is in_progress** — (`br update <id> --status in_progress`)
 4. [ ] **No file reservation conflicts** — Did Agent Mail confirm no conflicts? If conflicts were reported, was the Conflict Resolution Protocol completed?


### PR DESCRIPTION
## Summary
- Adds **Branch Isolation with Git Worktrees** section to `AGENTS.md` requiring `git worktree` for all feature branch work when multiple agents share a repo checkout
- Updates **Complete Feature Branch Workflow** to use worktrees instead of `git checkout -b`
- Updates **Session Close Protocol** cleanup step to include worktree removal
- Updates `CLAUDE.md` **Pre-Implementation Checklist** to reference worktrees with quick-start commands

## Context
When multiple Claude Code agents share a single repo checkout, any `git checkout` by one agent switches the branch for all agents. This causes:
- Uncommitted files lost when another agent switches branches
- `lint-staged` stash/pop applying to wrong branch during commits
- Branch state changing between consecutive commands

Git worktrees provide isolated checkouts that are immune to other agents' branch switches.

## Test plan
- [ ] Verify `AGENTS.md` renders correctly with the new Branch Isolation section
- [ ] Verify `CLAUDE.md` Pre-Implementation Checklist includes worktree commands
- [ ] Verify placeholder paths (`<project>`, `<project-root>`) are generic for boilerplate use

🤖 Generated with [Claude Code](https://claude.com/claude-code)